### PR TITLE
[OR-793] add l2 health check method (not permit request without anything in proxyd)

### DIFF
--- a/ops/scripts/batch-submitter.sh
+++ b/ops/scripts/batch-submitter.sh
@@ -21,6 +21,13 @@ curl --fail \
     --retry $RETRIES \
     --retry-delay 1 \
     --output /dev/null \
+    --header 'Content-Type: application/json' \
+    --data '{
+      "jsonrpc":"2.0",
+      "method":"eth_blockNumber",
+      "params":[],
+      "id":83
+    }' \
     $L2_ETH_RPC
 
 # go

--- a/ops/scripts/relayer.sh
+++ b/ops/scripts/relayer.sh
@@ -20,6 +20,13 @@ curl \
     --retry-connrefused \
     --retry $RETRIES \
     --retry-delay 1 \
+    --header 'Content-Type: application/json' \
+    --data '{
+      "jsonrpc":"2.0",
+      "method":"eth_blockNumber",
+      "params":[],
+      "id":83
+    }' \
     $MESSAGE_RELAYER__L2_RPC_PROVIDER
 
 # go


### PR DESCRIPTION
- add l2 health check method because of proxy package.

we are using a proxy for l2 request, but the proxy doesn't permit request without path and body. so I added health check mehod after internal test.

thank you!