### PR TITLE
[OR-723] github action for titan packages

### DIFF
--- a/.github/workflows/titan-packages-release.yml
+++ b/.github/workflows/titan-packages-release.yml
@@ -2,7 +2,6 @@ name: Publish the Titan Packages
 
 on:
   push:
-    # will be change to main
     branches:
       - main
 

--- a/.github/workflows/titan-packages-release.yml
+++ b/.github/workflows/titan-packages-release.yml
@@ -14,11 +14,15 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
 
-      - name: Setup Node.js 16.x
-        uses: actions/setup-node@master
+      - name: Setup Node 16.x
+        uses: actions/setup-node@v3
         with:
-          node-version: 16.x
-          registry-url: "https://registry.npmjs.org"
+          node-version: 16
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/titan-packages-release.yml
+++ b/.github/workflows/titan-packages-release.yml
@@ -4,7 +4,7 @@ on:
   push:
     # will be change to main
     branches:
-      - OR-723_titan-sdk-ci-cd
+      - main
 
 jobs:
   release:
@@ -31,7 +31,6 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > .npmrc
 
-      # publish titan-sdk package
       - name: Filter packages to publish
         id: filter-packages
         run: |

--- a/.github/workflows/titan-packages-release.yml
+++ b/.github/workflows/titan-packages-release.yml
@@ -1,4 +1,4 @@
-name: Release the Titan Packages
+name: Publish the Titan Packages
 
 on:
   push:
@@ -27,20 +27,28 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
-      # prune invailid tags in local
-      - name: Fetch Tags
-        run: git fetch --prune --tags
-
       - name: Create .npmrc
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > .npmrc
 
-      - name: Create Release Pull Request or Publish to npm
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          publish: yarn release
-          createGithubReleases: false
+      # publish titan-sdk package
+      - name: Filter packages to publish
+        id: filter-packages
+        run: |
+          # Define the package names to publish
+          PACKAGES_TO_PUBLISH=("@tokamak-network/titan-sdk")
+          # Set the output variables for packages to publish
+          echo "::set-output name=packages-to-publish::${PACKAGES_TO_PUBLISH[*]}"
+
+      - name: Publish Packages
+        run: |
+          echo "The packages will be published are ${{ steps.filter-packages.outputs.packages-to-publish }}"
+          for PACKAGE in ${{ steps.filter-packages.outputs.packages-to-publish }}; do
+            if yarn workspace $PACKAGE publish; then
+              echo "Package $PACKAGE published successfully!"
+            else
+              echo "Skipping package $PACKAGE publishing as it encountered an error."
+            fi
+          done
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/titan-packages-release.yml
+++ b/.github/workflows/titan-packages-release.yml
@@ -1,0 +1,42 @@
+name: Release the Titan Packages
+
+on:
+  push:
+    # will be change to main
+    branches:
+      - OR-723_titan-sdk-ci-cd
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js 16.x
+        uses: actions/setup-node@master
+        with:
+          node-version: 16.x
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      # prune invailid tags in local
+      - name: Fetch Tags
+        run: git fetch --prune --tags
+
+      - name: Create .npmrc
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN }}" > .npmrc
+
+      - name: Create Release Pull Request or Publish to npm
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          publish: yarn release
+          createGithubReleases: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/packages/tokamak/sdk/package.json
+++ b/packages/tokamak/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tokamak-network/titan-sdk",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "[Tokamak-Titan] Tools for working with Tokamak-Titan",
   "main": "dist/index",
   "types": "dist/index",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3151,28 +3151,6 @@
     traverse "^0.6.6"
     unified "^9.2.2"
 
-"@tokamak-network/titan-contracts@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@tokamak-network/titan-contracts/-/titan-contracts-0.0.1.tgz#49f9932e6b6ed744ac36dcfe2f6deec251ab3e0a"
-  integrity sha512-/bd4gWHsu4RAMC0EsSHxYj+BFW6I3tskhcxMRKb669T+sklhtAjHOLLWCkCv81VKmuJ0mlrAKh5Y3yf406N9BA==
-  dependencies:
-    "@eth-optimism/core-utils" "0.10.1"
-    "@ethersproject/abstract-provider" "^5.7.0"
-    "@ethersproject/abstract-signer" "^5.7.0"
-
-"@tokamak-network/titan-sdk@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@tokamak-network/titan-sdk/-/titan-sdk-0.0.2.tgz#6c7477e75fc1372b4235a40ac5a6701dc66d3e7c"
-  integrity sha512-QdG5bAicTWtgaU2CNdeA1TpEKqnziiuT81y13otLLrlCkymfB2ruKwFpg/Rv+1XH5QeqnRoVv3xoVa74bJWFTA==
-  dependencies:
-    "@eth-optimism/contracts-bedrock" "0.8.0"
-    "@eth-optimism/core-utils" "0.10.1"
-    "@tokamak-network/titan-contracts" "0.0.1"
-    lodash "^4.17.21"
-    merkletreejs "^0.2.27"
-    rlp "^2.2.7"
-    typescript "^4.6.2"
-
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"


### PR DESCRIPTION
added github action workflow for titan packages

* target branch: main
* determine packages to publish (will be add @tokamak-network/titan-contracts in filter)
* publish packages to npm (if local package version is lower than npm registry, skip the publish the package. so we should bump version after we change code of titan packages)