### PR TITLE
[OR-873] change trigger of titan npm package ci/cd

### DIFF
--- a/.github/workflows/titan-packages-release.yml
+++ b/.github/workflows/titan-packages-release.yml
@@ -2,8 +2,8 @@ name: Publish the Titan Packages
 
 on:
   push:
-    branches:
-      - main
+    tags:
+      - 'release-*'
 
 jobs:
   release:


### PR DESCRIPTION
changed the conditions under which the github action workflow is triggered **to provide stable packages** to the public npm registry.

- from: push event occurs on main branch
- to: push event occurs that pushes a tag of the form 'release-*'

Thanks to @harryoh 