### PR TITLE
Fix minor typo in ops README

### DIFF
--- a/ops/README.md
+++ b/ops/README.md
@@ -53,7 +53,7 @@ docker-compose
     --build --detach
 ```
 
-A Makefile has been provided for convience. The following targets are available.
+A Makefile has been provided for convenience. The following targets are available.
 - make up
 - make down
 - make up-metrics


### PR DESCRIPTION
I noticed a very minor typo while reading through the file.