### PR TITLE
Modified ops/docker/hardhat/Dockerfile

### DIFF
--- a/ops/docker/hardhat/Dockerfile
+++ b/ops/docker/hardhat/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 # bring in the config files for installing deps
 COPY [ \


### PR DESCRIPTION
When building with the existing code, the following error occurs.

`@nomicfoundation/ethereumjs-util@9.0.4: The engine "node" is incompatible with this module. Expected version ">=18". Got "16.20.2"`

Fixed node version from 16 to 18.